### PR TITLE
TRO-762 script to change namespace on alerts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,6 @@ FROM python:3.10-slim
 WORKDIR /app
 COPY requirements.txt ./
 RUN pip install -r requirements.txt
-COPY grafana-sync.py ./
-ENTRYPOINT [ "./grafana-sync.py" ]
+COPY grafana_sync.py ./
+ENTRYPOINT [ "./grafana_sync.py" ]
 CMD [ "--help" ]

--- a/README.md
+++ b/README.md
@@ -139,3 +139,17 @@ minikube service -n monitoring prometheus
 ```sh 
 curl -X POST -H "Content-Type: application/json" -d '{"name":"apikeycurl", "role": "Admin"}' http://admin:admin@localhost:3000/api/auth/keys
 ```
+
+# update_alert
+
+There is a little utility to update namespaces on alerts.
+
+## usage
+
+Similar to `grafana_sync`. The environments variables used are the `SOURCE_` ones only.
+
+
+```bash
+source .local.env
+python ./update_alert.py -g="http://localhost:3000" -o=sts -d=sts-evaluation
+```

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ $ docker build . --tag grafana-sync
  => CACHED [2/5] WORKDIR /app                                                                                         0.0s
  => CACHED [3/5] COPY requirements.txt ./                                                                             0.0s
  => CACHED [4/5] RUN pip install -r requirements.txt                                                                  0.0s
- => CACHED [5/5] COPY grafana-sync.py ./                                                                              0.0s
+ => CACHED [5/5] COPY grafana_sync.py ./                                                                              0.0s
  => exporting to image                                                                                                0.1s
  => => exporting layers                                                                                               0.0s
  => => writing image sha256:370213b80f9bd3e0a12a5084f760a78358c9a4ad9a335722caf9bb48dbff5b08                          0.0s
@@ -39,7 +39,7 @@ $ docker run --rm grafana-sync
 ### Usage
 
 ```
-usage: grafana-sync.py [-h] -s SOURCE -t TARGET [-f] [-q | -v] {dashboards,alerts} [{dashboards,alerts} ...]
+usage: grafana_sync.py [-h] -s SOURCE -t TARGET [-f] [-q | -v] {dashboards,alerts} [{dashboards,alerts} ...]
 
 Copies dashboards and / or alerts between local storage and Grafana server
 

--- a/grafana_sync.py
+++ b/grafana_sync.py
@@ -466,7 +466,8 @@ def main():
         raise NotImplementedError('Item not implemented... yet!')
 
 
-if __name__ == '__main__':
+def config_loggin():
+    global pprint_size
     if sys.stdout.isatty():
         RST = '\u001b[0m'
         RED = '\u001b[31m'
@@ -474,15 +475,18 @@ if __name__ == '__main__':
         YLW = '\u001b[33m'
         MGN = '\u001b[35m'
         CYA = '\u001b[36m'
-        logging.addLevelName(logging.DEBUG,    CYA + 'DEBUG'    + RST)
-        logging.addLevelName(logging.INFO,     GRN + 'INFO'     + RST)
-        logging.addLevelName(logging.WARNING,  YLW + 'WARNING'  + RST)
-        logging.addLevelName(logging.ERROR,    RED + 'ERROR'    + RST)
+        logging.addLevelName(logging.DEBUG, CYA + 'DEBUG' + RST)
+        logging.addLevelName(logging.INFO, GRN + 'INFO' + RST)
+        logging.addLevelName(logging.WARNING, YLW + 'WARNING' + RST)
+        logging.addLevelName(logging.ERROR, RED + 'ERROR' + RST)
         logging.addLevelName(logging.CRITICAL, MGN + 'CRITICAL' + RST)
 
         pprint_size = os.get_terminal_size().columns
-    
     logging.basicConfig(level=logging.DEBUG)
+
+
+if __name__ == '__main__':
+    config_loggin()
     try:
         sys.exit(main())
     except requests.exceptions.HTTPError as error:

--- a/grafana_sync.py
+++ b/grafana_sync.py
@@ -154,7 +154,7 @@ def save_folder(f: dict, path, exist_skip=True):
 
 def is_alert(data_json):
     """basic sanity check of a few required fields"""
-    return all(item in data_json for item in {'ruleGroup', 'title'})
+    return 'uid' in data_json and all(item in data_json for item in {'ruleGroup', 'title'})
 
 def create_alert(base_url, session, data_json, overwrite=False, adapt_uid=False) -> Optional[str]:
     """Create new alert in Grafana server.
@@ -163,20 +163,22 @@ def create_alert(base_url, session, data_json, overwrite=False, adapt_uid=False)
     """
     if not is_alert(data_json):
         raise ValueError("JSON contains no alert rule")
-    if overwrite:
-        raise NotImplementedError('Can not overwrite alerts yet')
-    elif 'uid' in data_json:
-        data = get_alert_rule(base_url, session, data_json['uid'], check_status=False)
-        if is_alert(data):
-            LOGGER.debug('Skipped already existing alert: %s "%s"',
-                data_json['uid'], data_json['title'])
-            return
-    if 'annotations' in data_json:
+    data = get_alert_rule(base_url, session, data_json['uid'], check_status=False)
+    if not overwrite and is_alert(data):
+        LOGGER.debug('Skipped already existing alert: %s "%s"',
+                     data_json['uid'], data_json['title'])
+        return
+    if not overwrite and 'annotations' in data_json:
         # annotations may reference UIDs of not existing dashboards...
         # TODO: adapt dashboard uids, or only allow setting the alert with its dashboard maybe
         del data_json['annotations']
     # TODO: adapt datasource uids
-    request = session.post(base_url + '/api/v1/provisioning/alert-rules', json=data_json)
+    create_url = base_url + '/api/v1/provisioning/alert-rules'
+    if is_alert(data):
+        update_url = create_url + f"/{data['uid']}"
+        request = session.put(update_url, json=data_json)
+    else:
+        request = session.post(create_url, json=data_json)
     new_alert = request.json()
     LOGGER.debug('set_alert:\n%s', pretty_json(new_alert))
     request.raise_for_status()
@@ -335,28 +337,36 @@ class GrafanaClient:
         else:
             self.__save_alerts_to_file(source.folders, source.alerts)
 
-    def __sync_folders_with(self, source: 'GrafanaClient', update_children: Callable[[dict, dict], None])-> None:
+    def save_alert(self, alert: dict, overwrite: bool = None) -> None:
+        if not overwrite:
+            overwrite = self.overwrite
+        if self.url.startswith('http'):
+            create_alert(self.url, self.session, alert, overwrite=overwrite)
+        else:
+            save_alert(alert, self.url, exist_skip=self.overwrite)
+
+    def __sync_folders_with(self, source: 'GrafanaClient', update_childs: Callable[[dict, dict], None])-> None:
         for source_folder in source.folders:
             current_folder = self.__find_folder(source_folder)
             if not current_folder:
                 create_folder(self.url, self.session, source_folder)
-            if self.overwrite and current_folder is not None and not current_folder['title'] == source_folder['title']:
+            elif self.overwrite and current_folder is not None and not current_folder['title'] == source_folder['title']:
                 current_folder['title'] = source_folder['title']
                 update_folder(self.url, self.session, current_folder)
-            if current_folder is not None and not current_folder['uid'] == source_folder['uid']:
-                update_children(source_folder, current_folder)
+            elif not current_folder['uid'] == source_folder['uid']:
+                update_childs(source_folder, current_folder)
 
-    def __save_alert_to_grafana(self, alerts: list):
+    def __save_alert_to_grafana(self, alerts:list):
         LOGGER.info(f"Saving alerts to {self.url}")
         for a in alerts:
-            create_alert(self.url, self.session, a)
+           self.save_alert(a)
 
     def __save_alerts_to_file(self, folders: dict, alerts: list):
         LOGGER.info(f"Saving alerts file {self.url}")
         for f in folders:
             save_folder(f, self.url, exist_skip=self.overwrite)
         for a in alerts:
-            save_alert(a, self.url, exist_skip=self.overwrite)
+            self.save_alert(a)
 
     def __load_folders(self)-> dict:
         if self.url.startswith('http'):
@@ -388,6 +398,29 @@ class GrafanaClient:
             if alert['folderUID'] == source_folder['uid']:
                 alert['folderUID'] = target_folder['uid']
 
+def config_logging(args: argparse.Namespace) -> None:
+    global pprint_size
+    if sys.stdout.isatty():
+        RST = '\u001b[0m'
+        RED = '\u001b[31m'
+        GRN = '\u001b[32m'
+        YLW = '\u001b[33m'
+        MGN = '\u001b[35m'
+        CYA = '\u001b[36m'
+        logging.addLevelName(logging.DEBUG, CYA + 'DEBUG' + RST)
+        logging.addLevelName(logging.INFO, GRN + 'INFO' + RST)
+        logging.addLevelName(logging.WARNING, YLW + 'WARNING' + RST)
+        logging.addLevelName(logging.ERROR, RED + 'ERROR' + RST)
+        logging.addLevelName(logging.CRITICAL, MGN + 'CRITICAL' + RST)
+
+        pprint_size = os.get_terminal_size().columns
+    logging.basicConfig(level=logging.DEBUG)
+    logging.getLogger().setLevel(logging.INFO)
+    if args.quiet:
+        logging.getLogger().setLevel(logging.WARNING)
+    elif args.verbose:
+        logging.getLogger().setLevel(logging.DEBUG)
+
 def main():
     parser = argparse.ArgumentParser(
         description='Copies dashboards and / or alerts between local storage and Grafana server',
@@ -398,17 +431,13 @@ def main():
     parser.add_argument('-t', '--target', required=True, help="Copy target: Grafana server HTTPS URL, or path to local folder")
     parser.add_argument('-f', '--force-overwrite', action='store_true')
     parser.add_argument('items', help='What items should be copied from source to destination?',
-        nargs='+', choices=['dashboards', 'alerts'])
+                        nargs='+', choices=['dashboards', 'alerts'])
     verbosity = parser.add_mutually_exclusive_group()
     verbosity.add_argument('-q', '--quiet', action='store_true')
     verbosity.add_argument('-v', '--verbose', action='store_true')
     args = parser.parse_args()
 
-    logging.getLogger().setLevel(logging.INFO)
-    if args.quiet:
-        logging.getLogger().setLevel(logging.WARNING)
-    elif args.verbose:
-        logging.getLogger().setLevel(logging.DEBUG)
+    config_logging(args)
 
     if args.source and args.source.startswith('http'):
         if all((not SOURCE_GRAFANA_TOKEN, not SOURCE_GRAFANA_USER, not SOURCE_GRAFANA_PASSWORD)):
@@ -417,7 +446,7 @@ def main():
             return 1
 
         source_session = GrafanaLogin(SOURCE_GRAFANA_TOKEN,SOURCE_GRAFANA_USER,SOURCE_GRAFANA_PASSWORD, args.source)
-        source = GrafanaClient(args.source, source_session, overwrite=args.force_overwrite is not None)
+        source = GrafanaClient(args.source, source_session, overwrite=args.force_overwrite)
 
     if args.target and args.target.startswith('http'):
         if all((not TARGET_GRAFANA_TOKEN, not TARGET_GRAFANA_USER, not TARGET_GRAFANA_PASSWORD)):
@@ -426,7 +455,7 @@ def main():
             return 1
 
         target_session = GrafanaLogin(TARGET_GRAFANA_TOKEN, TARGET_GRAFANA_USER, TARGET_GRAFANA_PASSWORD, args.target)
-        target = GrafanaClient(args.target, target_session, overwrite=args.force_overwrite is not None)
+        target = GrafanaClient(args.target, target_session, overwrite=args.force_overwrite)
 
     if 'dashboards' in args.items:
         LOGGER.info('Loading dashboards')
@@ -466,27 +495,7 @@ def main():
         raise NotImplementedError('Item not implemented... yet!')
 
 
-def config_loggin():
-    global pprint_size
-    if sys.stdout.isatty():
-        RST = '\u001b[0m'
-        RED = '\u001b[31m'
-        GRN = '\u001b[32m'
-        YLW = '\u001b[33m'
-        MGN = '\u001b[35m'
-        CYA = '\u001b[36m'
-        logging.addLevelName(logging.DEBUG, CYA + 'DEBUG' + RST)
-        logging.addLevelName(logging.INFO, GRN + 'INFO' + RST)
-        logging.addLevelName(logging.WARNING, YLW + 'WARNING' + RST)
-        logging.addLevelName(logging.ERROR, RED + 'ERROR' + RST)
-        logging.addLevelName(logging.CRITICAL, MGN + 'CRITICAL' + RST)
-
-        pprint_size = os.get_terminal_size().columns
-    logging.basicConfig(level=logging.DEBUG)
-
-
 if __name__ == '__main__':
-    config_loggin()
     try:
         sys.exit(main())
     except requests.exceptions.HTTPError as error:

--- a/update_alert.py
+++ b/update_alert.py
@@ -1,0 +1,3 @@
+import grafana_sync
+
+grafana_sync.config_loggin()

--- a/update_alert.py
+++ b/update_alert.py
@@ -1,3 +1,73 @@
-import grafana_sync
+import logging
 
-grafana_sync.config_loggin()
+import grafana_sync
+import sys
+import requests
+import argparse
+
+EXIT_SUCCESS = 0
+EXIT_ERROR = 1
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description='Change source namespace to target namespace on all alerts',
+        epilog=grafana_sync.DOC_EPILOG,
+        formatter_class=argparse.RawDescriptionHelpFormatter  # do not remove newlines from DOC_EPILOG
+    )
+    parser.add_argument('-g', '--grafana_url', required=True,
+                        help="URL of the Grafana server whose alerts shall be updated")
+    parser.add_argument('-o', '--origin_namespace', required=True,
+                        help="The namespace to be renamed from")
+    parser.add_argument('-d', '--destination_namespace', required=True,
+                        help="The namespace to be renamed to")
+    verbosity = parser.add_mutually_exclusive_group()
+    verbosity.add_argument('-q', '--quiet', action='store_true')
+    verbosity.add_argument('-v', '--verbose', action='store_true')
+    return parser.parse_args()
+
+def __get_models_with_expression(alert: dict) -> list:
+    expressions = list()
+    if alert and 'data' in alert:
+        for data in alert['data']:
+            if 'model' in data and 'expr' in data['model']:
+                expressions.append(data['model'])
+    return expressions
+
+def __change_namespace(grafana: grafana_sync.GrafanaClient, origin_namespace: str, destination_namespace: str) -> None:
+    for alert in grafana.alerts:
+        alert_needs_update = False
+        for model in __get_models_with_expression(alert):
+            namespace_pattern = f'="{origin_namespace}"'
+            if namespace_pattern in model['expr']:
+                alert_needs_update = True
+                logging.debug(f"on alert '{alert['title']}' we will modify { model['expr']}")
+                model['expr'] = model['expr'].replace(namespace_pattern,f'="{destination_namespace}"')
+        if alert_needs_update:
+            logging.info(f"alert {alert['uid']}('{alert['title']}') has been modified")
+            grafana.save_alert(alert, overwrite=True)
+
+def change_namespace(grafana: grafana_sync.GrafanaClient, origin_namespace, destination_namespace) -> int:
+    try:
+        logging.info("Changing namespace to alerts")
+        __change_namespace(grafana, origin_namespace, destination_namespace)
+        return EXIT_SUCCESS
+    except requests.exceptions.HTTPError as error:
+        logging.error(
+            f"REST call has failed. The request is {error.request.url} Status is {error.response.status_code} and error is {error.response.text}",
+            error)
+        return EXIT_ERROR
+
+def login_to_grafana(args: argparse.Namespace) -> grafana_sync.GrafanaClient:
+    grafana_url = args.grafana_url
+    token = grafana_sync.SOURCE_GRAFANA_TOKEN
+    username = grafana_sync.SOURCE_GRAFANA_USER
+    password = grafana_sync.SOURCE_GRAFANA_PASSWORD
+    login = grafana_sync.GrafanaLogin(token, username, password, grafana_url)
+    return grafana_sync.GrafanaClient(grafana_url,login, False)
+
+if __name__ == '__main__':
+    args = parse_args()
+    grafana_sync.config_logging(args)
+    client = login_to_grafana(args)
+
+    sys.exit(change_namespace(client, args.origin_namespace, args.destination_namespace))


### PR DESCRIPTION
When we migrated from production to sss-eval alerts we had problems with the alerts. On production we use the namespace sts and in sss-eval we use sts-evaluation. 

I made a script to update that